### PR TITLE
Fix CEP validation

### DIFF
--- a/loaders/cepsAvailable.tsx
+++ b/loaders/cepsAvailable.tsx
@@ -1,30 +1,3 @@
-<<<<<<< HEAD
-import Papa from "https://esm.sh/papaparse@5.4.1";
-
-export interface Props {
-  cepsCsvUrl: string; // arquivo do CMS (upload de CSV)
-}
-
-interface CsvCep {
-  cep: string;
-}
-
-export default async function loader({ cepsCsvUrl }: Props, req: Request) {
-  const res = await fetch(cepsCsvUrl);
-  const text = await res.text();
-
-  const parsed = Papa.parse<CsvCep>(text, { header: true });
-  const validCeps = parsed.data.map(({ cep }) => cep.trim());
-
-  const cookies = Object.fromEntries(
-    req.headers.get("cookie")?.split("; ").map((c) => c.split("=")) ?? [],
-  );
-  const userCep = cookies["__dc-cep"];
-
-  return {
-    cep: userCep,
-    isAvailable: validCeps.includes(userCep),
-=======
 import { parse } from "@std/encoding/csv";
 
 interface Props {
@@ -53,7 +26,6 @@ async function loadData(path: string): Promise<string> {
     if (!res.ok) throw new Error(`Failed to fetch ${path}`);
     return await res.text();
   }
-  // Remove leading slash if exists
   const filePath = path.startsWith("/") ? path.slice(1) : path;
   return await Deno.readTextFile(filePath);
 }
@@ -70,6 +42,5 @@ export default async function loader(
   const match = records.some((r) => normalize(r["cep"] || "") === normalized);
   return {
     available: match,
->>>>>>> 46bc82c719b11f534566e1c872b5450b0c5edd47
   };
 }

--- a/routes/api/verifica-cep.tsx
+++ b/routes/api/verifica-cep.tsx
@@ -1,17 +1,57 @@
 import { Handlers } from "$fresh/server.ts";
 import Papa from "https://esm.sh/papaparse@5.4.1";
+import { h } from "preact";
 import { renderToString } from "preact-render-to-string";
 
-function FormHtml(csvUrl: string) { /* igual antes */ }
-function SuccessHtml({ cep }: { cep: string }) { /* igual antes */ }
-function UnavailableHtml({ cep }: { cep: string }) { /* igual antes */ }
+function FormHtml({ csvUrl, cep = "" }: { csvUrl: string; cep?: string }) {
+  return (
+    <form
+      class="cep-form flex gap-2 items-end"
+      hx-post={`/api/verifica-cep?csv=${encodeURIComponent(csvUrl)}`}
+      hx-target="this"
+      hx-swap="outerHTML"
+    >
+      <input
+        type="text"
+        name="cep"
+        class="input input-bordered"
+        placeholder="00000-000"
+        value={cep}
+      />
+      <button type="submit" class="btn btn-primary">
+        <span class="[.htmx-request_&]:hidden">Consultar</span>
+        <span class="hidden [.htmx-request_&]:inline loading loading-spinner loading-xs" />
+      </button>
+    </form>
+  );
+}
+
+function SuccessHtml({ cep, csvUrl }: { cep: string; csvUrl: string }) {
+  return (
+    <div class="cep-success p-4 bg-green-200 text-green-800 rounded-xl space-y-2">
+      <p>O CEP {cep} está disponível para entrega.</p>
+      <FormHtml csvUrl={csvUrl} cep={cep} />
+    </div>
+  );
+}
+
+function UnavailableHtml({ cep, csvUrl }: { cep: string; csvUrl: string }) {
+  return (
+    <div class="cep-unavailable p-4 bg-red-200 text-red-800 rounded-xl space-y-2">
+      <p>Infelizmente não entregamos no CEP {cep}.</p>
+      <FormHtml csvUrl={csvUrl} cep={cep} />
+    </div>
+  );
+}
 
 export const handler: Handlers = {
   async GET(req) {
     const url = new URL(req.url);
     const csvUrl = url.searchParams.get("csv") ?? "";
-    const html = renderToString(FormHtml(csvUrl));
-    return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
+    const html = renderToString(<FormHtml csvUrl={csvUrl} />);
+    return new Response(html, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   },
   async POST(req) {
     const url = new URL(req.url);
@@ -19,14 +59,16 @@ export const handler: Handlers = {
     const form = await req.formData();
     const cep = form.get("cep")?.toString().trim() ?? "";
 
-    const csvText = await fetch(csvUrl).then(res => res.text());
+    const csvText = await fetch(csvUrl).then((res) => res.text());
     const parsed = Papa.parse<{ cep: string }>(csvText, { header: true });
-    const cepsValidos = parsed.data.map(r => r.cep?.trim()).filter(Boolean);
+    const cepsValidos = parsed.data.map((r) => r.cep?.trim()).filter(Boolean);
 
     const html = cepsValidos.includes(cep)
-      ? renderToString(<SuccessHtml cep={cep} />)
-      : renderToString(<UnavailableHtml cep={cep} />);
+      ? renderToString(<SuccessHtml cep={cep} csvUrl={csvUrl} />)
+      : renderToString(<UnavailableHtml cep={cep} csvUrl={csvUrl} />);
 
-    return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
+    return new Response(html, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   },
 };


### PR DESCRIPTION
## Summary
- resolve merge conflict in `cepsAvailable` loader
- implement `FormHtml`, `SuccessHtml` and `UnavailableHtml` in `verifica-cep` API

## Testing
- `deno` command unavailable, so checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_68521c3ee1d4832589052da974172737