### PR TITLE
Fix CepValidation modal

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -16,3 +16,5 @@ export const HEADER_HEIGHT_MOBILE = "104px";
 export const NAVBAR_HEIGHT_MOBILE = "56px";
 export const HEADER_HEIGHT_DESKTOP = "176px";
 export const NAVBAR_HEIGHT_DESKTOP = "44px";
+
+export const CEP_VALIDATION_MODAL_ID = "cep-validation-modal";

--- a/routes/api/verifica-cep.tsx
+++ b/routes/api/verifica-cep.tsx
@@ -1,7 +1,19 @@
 import { Handlers } from "$fresh/server.ts";
-import Papa from "https://esm.sh/papaparse@5.4.1";
 import { h } from "preact";
 import { renderToString } from "preact-render-to-string";
+import Modal from "../../components/ui/Modal.tsx";
+import { CEP_VALIDATION_MODAL_ID } from "../../constants.ts";
+
+function parseCsv(text: string) {
+  const lines = text.trim().split(/\r?\n/).filter(Boolean);
+  const header = lines.shift();
+  if (!header) return [] as string[];
+  const headers = header.split(/,\s*/);
+  const idx = headers.findIndex((h) => h.trim() === "cep");
+  return lines
+    .map((line) => line.split(/,\s*/)[idx]?.trim())
+    .filter(Boolean);
+}
 
 function FormHtml({ csvUrl, cep = "" }: { csvUrl: string; cep?: string }) {
   return (
@@ -44,11 +56,19 @@ function UnavailableHtml({ cep, csvUrl }: { cep: string; csvUrl: string }) {
   );
 }
 
+function wrap(content: h.JSX.Element) {
+  return (
+    <Modal id={CEP_VALIDATION_MODAL_ID} open>
+      <div class="modal-box">{content}</div>
+    </Modal>
+  );
+}
+
 export const handler: Handlers = {
   async GET(req) {
     const url = new URL(req.url);
     const csvUrl = url.searchParams.get("csv") ?? "";
-    const html = renderToString(<FormHtml csvUrl={csvUrl} />);
+    const html = renderToString(wrap(<FormHtml csvUrl={csvUrl} />));
     return new Response(html, {
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
@@ -60,12 +80,11 @@ export const handler: Handlers = {
     const cep = form.get("cep")?.toString().trim() ?? "";
 
     const csvText = await fetch(csvUrl).then((res) => res.text());
-    const parsed = Papa.parse<{ cep: string }>(csvText, { header: true });
-    const cepsValidos = parsed.data.map((r) => r.cep?.trim()).filter(Boolean);
+    const cepsValidos = parseCsv(csvText);
 
     const html = cepsValidos.includes(cep)
-      ? renderToString(<SuccessHtml cep={cep} csvUrl={csvUrl} />)
-      : renderToString(<UnavailableHtml cep={cep} csvUrl={csvUrl} />);
+      ? renderToString(wrap(<SuccessHtml cep={cep} csvUrl={csvUrl} />))
+      : renderToString(wrap(<UnavailableHtml cep={cep} csvUrl={csvUrl} />));
 
     return new Response(html, {
       headers: { "Content-Type": "text/html; charset=utf-8" },

--- a/sections/CepValidation/CepValidation.tsx
+++ b/sections/CepValidation/CepValidation.tsx
@@ -1,16 +1,21 @@
 
 
+import { CEP_VALIDATION_MODAL_ID } from "../../constants.ts";
+
 export interface Props {
   cepsCsvUrl: string;
 }
 
 export default function CepValidation({ cepsCsvUrl }: Props) {
   return (
-    <div
-      hx-get={`/api/verifica-cep?csv=${encodeURIComponent(cepsCsvUrl)}`}
-      hx-trigger="load"
-      hx-target="body"
-      hx-swap="beforeend"
-    />
+    <>
+      <label for={CEP_VALIDATION_MODAL_ID} class="btn">Consultar CEP</label>
+      <div
+        hx-get={`/api/verifica-cep?csv=${encodeURIComponent(cepsCsvUrl)}`}
+        hx-trigger="load"
+        hx-target="body"
+        hx-swap="beforeend"
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- create constant CEP_VALIDATION_MODAL_ID
- implement simple CSV parser and modal markup in CEP validation route
- add button and lazy loaded modal for CEP validation section

## Testing
- `deno task check` *(fails: deno: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852229a18fc8325aa248b98b0197596