### PR TITLE
chore: replace legacy asset URLs with decoims.com

### DIFF
--- a/.deco/blocks/Category%20Banner%20-%2001.json
+++ b/.deco/blocks/Category%20Banner%20-%2001.json
@@ -2,8 +2,8 @@
   "banners": [
     {
       "image": {
-        "mobile": "https://assets.decocache.com/storefront/b79aa236-d06d-481f-adf7-2f1076ea6210/1742560270734-91102b71-4832-486a-b683-5f7b06f649af",
-        "desktop": "https://assets.decocache.com/storefront/ca7dd51a-e5ae-491a-b72a-08c07aa4a70d/1742560272355-ec597b6a-dcf1-48ca-a99d-95b3c6304f96"
+        "mobile": "https://decoims.com/storefront/b79aa236-d06d-481f-adf7-2f1076ea6210/1742560270734-91102b71-4832-486a-b683-5f7b06f649af",
+        "desktop": "https://decoims.com/storefront/ca7dd51a-e5ae-491a-b72a-08c07aa4a70d/1742560272355-ec597b6a-dcf1-48ca-a99d-95b3c6304f96"
       },
       "title": "Woman",
       "matcher": "/feminino/*",
@@ -11,8 +11,8 @@
     },
     {
       "image": {
-        "mobile": "https://assets.decocache.com/storefront/b79aa236-d06d-481f-adf7-2f1076ea6210/1742560270734-91102b71-4832-486a-b683-5f7b06f649af",
-        "desktop": "https://assets.decocache.com/storefront/ca7dd51a-e5ae-491a-b72a-08c07aa4a70d/1742560272355-ec597b6a-dcf1-48ca-a99d-95b3c6304f96"
+        "mobile": "https://decoims.com/storefront/b79aa236-d06d-481f-adf7-2f1076ea6210/1742560270734-91102b71-4832-486a-b683-5f7b06f649af",
+        "desktop": "https://decoims.com/storefront/ca7dd51a-e5ae-491a-b72a-08c07aa4a70d/1742560272355-ec597b6a-dcf1-48ca-a99d-95b3c6304f96"
       },
       "title": "Woman",
       "matcher": "/*",

--- a/.deco/blocks/Footer.json
+++ b/.deco/blocks/Footer.json
@@ -90,7 +90,7 @@
         {
           "title": "SAC: +55 (35) 99932-7472",
           "href": "tel:+5535999327472",
-          "icon": "https://assets.decocache.com/vida-veg-b2b/dab71271-0b8c-41fa-8942-12c394b51251/PhoneCall.svg"
+          "icon": "https://decoims.com/vida-veg-b2b/dab71271-0b8c-41fa-8942-12c394b51251/PhoneCall.svg"
         },
         {
           "title": "Contato",
@@ -111,24 +111,24 @@
     {
       "alt": "Linkedin",
       "href": "#",
-      "image": "https://assets.decocache.com/vida-veg-b2b/f4aeb6cc-0b1b-4833-8720-7f3fe70f4b49/bg-linkedin.svg"
+      "image": "https://decoims.com/vida-veg-b2b/f4aeb6cc-0b1b-4833-8720-7f3fe70f4b49/bg-linkedin.svg"
     },
     {
       "alt": "Facebook",
       "href": "#",
-      "image": "https://assets.decocache.com/vida-veg-b2b/5e0fa92e-4209-46b0-92ea-c299bc5fcc51/bg-face.svg"
+      "image": "https://decoims.com/vida-veg-b2b/5e0fa92e-4209-46b0-92ea-c299bc5fcc51/bg-face.svg"
     },
     {
       "alt": "Youtube",
-      "image": "https://assets.decocache.com/vida-veg-b2b/ce136fef-3553-4780-b722-bcc0efbb3e19/bg-youtube.svg"
+      "image": "https://decoims.com/vida-veg-b2b/ce136fef-3553-4780-b722-bcc0efbb3e19/bg-youtube.svg"
     },
     {
       "alt": "Instagram",
       "href": "#",
-      "image": "https://assets.decocache.com/vida-veg-b2b/b2b1f737-8fdd-49c7-8b94-8101589f82d3/bg-insta.svg"
+      "image": "https://decoims.com/vida-veg-b2b/b2b1f737-8fdd-49c7-8b94-8101589f82d3/bg-insta.svg"
     },
     {
-      "image": "https://assets.decocache.com/vida-veg-b2b/8ed3aa46-0888-4d43-9201-f5f18105a1a7/bg-twitter.svg",
+      "image": "https://decoims.com/vida-veg-b2b/8ed3aa46-0888-4d43-9201-f5f18105a1a7/bg-twitter.svg",
       "alt": "X",
       "href": "#"
     }
@@ -137,44 +137,44 @@
     {
       "alt": "Paypal",
       "href": "#",
-      "image": "https://assets.decocache.com/storefront/1429addc-152d-4ef6-83b3-11908d70bee4/1742560241202-7d858621-469e-4528-91b5-8c79fc413162"
+      "image": "https://decoims.com/storefront/1429addc-152d-4ef6-83b3-11908d70bee4/1742560241202-7d858621-469e-4528-91b5-8c79fc413162"
     },
     {
       "alt": "Mastercard",
-      "image": "https://assets.decocache.com/storefront/51d88757-a9e5-4cce-9c1b-c9b303646aba/1742560242494-88ab870c-4256-44b4-8da3-3cefe0436e87"
+      "image": "https://decoims.com/storefront/51d88757-a9e5-4cce-9c1b-c9b303646aba/1742560242494-88ab870c-4256-44b4-8da3-3cefe0436e87"
     },
     {
       "alt": "Maestro",
       "href": "#",
-      "image": "https://assets.decocache.com/storefront/9141b2d0-cef9-4229-aed3-73efd535a6e7/1742560243691-e94aaf80-25f5-4e23-8708-14d78ffdebbb"
+      "image": "https://decoims.com/storefront/9141b2d0-cef9-4229-aed3-73efd535a6e7/1742560243691-e94aaf80-25f5-4e23-8708-14d78ffdebbb"
     },
     {
       "alt": "Google Pay",
-      "image": "https://assets.decocache.com/storefront/4cb84926-ccd8-4ea7-9f0e-1598ecefd0e8/1742560245001-ccddc66e-baa8-4b44-a52c-ea48d8e111b5"
+      "image": "https://decoims.com/storefront/4cb84926-ccd8-4ea7-9f0e-1598ecefd0e8/1742560245001-ccddc66e-baa8-4b44-a52c-ea48d8e111b5"
     },
     {
       "alt": "Elo",
       "href": "#",
-      "image": "https://assets.decocache.com/storefront/b96a6dbf-316a-42f0-a521-ef3022375506/1742560246527-11f90dd4-91b5-4b60-9304-f8a7a9be84eb"
+      "image": "https://decoims.com/storefront/b96a6dbf-316a-42f0-a521-ef3022375506/1742560246527-11f90dd4-91b5-4b60-9304-f8a7a9be84eb"
     },
     {
       "alt": "Diners",
       "href": "#",
-      "image": "https://assets.decocache.com/storefront/cc7cbcf8-8bc1-479a-82e2-786b170cec6e/1742560247885-20bb8e66-5495-4f92-a6d0-4967a66f3a44"
+      "image": "https://decoims.com/storefront/cc7cbcf8-8bc1-479a-82e2-786b170cec6e/1742560247885-20bb8e66-5495-4f92-a6d0-4967a66f3a44"
     },
     {
       "alt": "Apple Pay",
       "href": "#",
-      "image": "https://assets.decocache.com/storefront/9cb1b1cd-3545-4875-8b3e-121eb555b9ce/1742560249131-d4227ed7-333d-49b8-b3e2-35719f606640"
+      "image": "https://decoims.com/storefront/9cb1b1cd-3545-4875-8b3e-121eb555b9ce/1742560249131-d4227ed7-333d-49b8-b3e2-35719f606640"
     },
     {
       "alt": "Amex",
       "href": "#",
-      "image": "https://assets.decocache.com/storefront/2cea1d1e-3c52-4cfa-8600-02c7fbe1702e/1742560250503-023472cf-782d-4a22-82d9-ecdf18466d96"
+      "image": "https://decoims.com/storefront/2cea1d1e-3c52-4cfa-8600-02c7fbe1702e/1742560250503-023472cf-782d-4a22-82d9-ecdf18466d96"
     },
     {
       "alt": "Visa",
-      "image": "https://assets.decocache.com/storefront/62408e42-e1e9-45d2-99ed-e0a161271bca/1742560251996-2d213fd6-2754-4e92-a6f1-03825f71c7af"
+      "image": "https://decoims.com/storefront/62408e42-e1e9-45d2-99ed-e0a161271bca/1742560251996-2d213fd6-2754-4e92-a6f1-03825f71c7af"
     }
   ],
   "logo": {
@@ -305,23 +305,23 @@
     "124": "2",
     "125": "0",
     "126": "9",
-    "image": "https://assets.decocache.com/vida-veg-b2b/f2fca469-9261-466c-9124-48e814704412/log-2.png",
+    "image": "https://decoims.com/vida-veg-b2b/f2fca469-9261-466c-9124-48e814704412/log-2.png",
     "width": 118,
     "height": 131
   },
   "trademark": "TM & © 2023 Deco Storefront, Inc.",
   "seals": [
     {
-      "image": "https://assets.decocache.com/vida-veg-b2b/272a9b63-1df5-42a3-b85e-0bcb2a632ada/EuReciclo-1-3c42004f-1.png"
+      "image": "https://decoims.com/vida-veg-b2b/272a9b63-1df5-42a3-b85e-0bcb2a632ada/EuReciclo-1-3c42004f-1.png"
     },
     {
-      "image": "https://assets.decocache.com/vida-veg-b2b/5a4985d4-a2c1-4046-8c72-842a50ca0384/ProdutoVegano-eb5ff098-1.png"
+      "image": "https://decoims.com/vida-veg-b2b/5a4985d4-a2c1-4046-8c72-842a50ca0384/ProdutoVegano-eb5ff098-1.png"
     },
     {
-      "image": "https://assets.decocache.com/vida-veg-b2b/ab27ca78-21d7-42f0-8670-e87ac392dced/LKB-ece7f7a9-1.png"
+      "image": "https://decoims.com/vida-veg-b2b/ab27ca78-21d7-42f0-8670-e87ac392dced/LKB-ece7f7a9-1.png"
     },
     {
-      "image": "https://assets.decocache.com/vida-veg-b2b/ed6f97c6-566e-430d-8055-ae827929c9c9/Design-sem-nome-1-1-c038204d-1.png"
+      "image": "https://decoims.com/vida-veg-b2b/ed6f97c6-566e-430d-8055-ae827929c9c9/Design-sem-nome-1-1-c038204d-1.png"
     }
   ]
 }

--- a/.deco/blocks/Header.json
+++ b/.deco/blocks/Header.json
@@ -14,7 +14,7 @@
     "<p>Get 10% off today: <strong>NEW10</strong></p>"
   ],
   "logo": {
-    "src": "https://data.decoassets.com/lp-vida-veg/25984b16-e82d-4fca-91fd-934dfbbe6ba4/logo-chef.png",
+    "src": "https://decoims.com/lp-vida-veg/25984b16-e82d-4fca-91fd-934dfbbe6ba4/logo-chef.png",
     "alt": "Deco Storefront",
     "width": 80,
     "height": 80
@@ -23,7 +23,7 @@
     {
       "children": [],
       "image": {
-        "url": "https://assets.decocache.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
+        "url": "https://decoims.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
       },
       "url": "/quem-somos",
       "name": "Quem Somos"
@@ -46,7 +46,7 @@
         }
       ],
       "image": {
-        "url": "https://assets.decocache.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
+        "url": "https://decoims.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
       },
       "name": "Food Service",
       "url": "/food-service",
@@ -62,7 +62,7 @@
         }
       ],
       "image": {
-        "url": "https://assets.decocache.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
+        "url": "https://decoims.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
       },
       "name": "Varejo",
       "url": "/varejo",
@@ -92,7 +92,7 @@
         }
       ],
       "image": {
-        "url": "https://assets.decocache.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
+        "url": "https://decoims.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
       },
       "url": "/produtos",
       "name": "Produtos",
@@ -108,7 +108,7 @@
       "url": "https://vidaveg.com.br/receita/",
       "name": "Blog",
       "image": {
-        "url": "https://assets.decocache.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
+        "url": "https://decoims.com/vida-veg-b2b/edceef97-66a1-4387-a497-a6d57207e090/Rectangle-171.png"
       }
     }
   ],

--- a/.deco/blocks/LinkTree%20-%2001.json
+++ b/.deco/blocks/LinkTree%20-%2001.json
@@ -63,7 +63,7 @@
   "header": {
     "link": "https://deco.cx",
     "logo": {
-      "img": "https://assets.decocache.com/storefront/3b1d56ce-c28c-4633-b7c9-ca2bd44494f6/1742560273744-3fa15eff-add9-4974-864c-7f952bca5180",
+      "img": "https://decoims.com/storefront/3b1d56ce-c28c-4633-b7c9-ca2bd44494f6/1742560273744-3fa15eff-add9-4974-864c-7f952bca5180",
       "width": 150,
       "height": 63
     },

--- a/.deco/blocks/Shoppable%20Banner%20-%2001.json
+++ b/.deco/blocks/Shoppable%20Banner%20-%2001.json
@@ -39,9 +39,9 @@
     "content": "Your description"
   },
   "image": {
-    "mobile": "https://assets.decocache.com/storefront/85e56dd9-b55e-4753-a803-f7d33f027ebf/1742560262273-23be366c-fa07-4520-9338-387ce77acabb",
+    "mobile": "https://decoims.com/storefront/85e56dd9-b55e-4753-a803-f7d33f027ebf/1742560262273-23be366c-fa07-4520-9338-387ce77acabb",
     "altText": "a",
-    "desktop": "https://assets.decocache.com/storefront/a19398f0-f2f7-4cea-b237-a0b475a50103/1742560268178-b79dcfc0-45b8-40c4-a3ba-310e66995529"
+    "desktop": "https://decoims.com/storefront/a19398f0-f2f7-4cea-b237-a0b475a50103/1742560268178-b79dcfc0-45b8-40c4-a3ba-310e66995529"
   },
   "title": {
     "layout": {

--- a/.deco/blocks/pages-Quem%2520Somos-262067.json
+++ b/.deco/blocks/pages-Quem%2520Somos-262067.json
@@ -30,7 +30,7 @@
               "__resolveType": "site/sections/Institutional/InfoCard.tsx",
               "content": "<h2>Posicionamento</h2><p><span>Somos uma Food Tech Plant Based que acredita na alimentação como forma de cuidar da vida e contribuir para um mundo melhor.</span></p><h2>Diferencial</h2><p><span>O maior e mais variado portifólio de produtos Plant Based do Brasil: Leites frescos Vegetais, Iogurtes, Queijos, Cremes e Pastas, Manteigas e Sobremesas.</span></p><h2>Propósito</h2><p><span>Contribuir para um mundo melhor facilitando o acesso a alimentos de base vegetal.</span></p><h2>Atuação</h2><p><span>Presente em todos os estados do Brasil.</span></p>",
               "image": {
-                "src": "https://assets.decocache.com/vida-veg-b2b/03b9952d-55d2-448f-9eb0-f336d871639b/image-4.png",
+                "src": "https://decoims.com/vida-veg-b2b/03b9952d-55d2-448f-9eb0-f336d871639b/image-4.png",
                 "alt": "Fundadores da Vida Veg"
               },
               "imageCaption": "Fundadores Álvaro e Anderson"
@@ -42,11 +42,11 @@
               "__resolveType": "site/sections/Institutional/TwoImages.tsx",
               "images": [
                 {
-                  "src": "https://assets.decocache.com/vida-veg-b2b/35eceb80-2369-4568-a1f5-0ddde48cd929/image-5-(1).png",
+                  "src": "https://decoims.com/vida-veg-b2b/35eceb80-2369-4568-a1f5-0ddde48cd929/image-5-(1).png",
                   "alt": "Exterior da Fábrica"
                 },
                 {
-                  "src": "https://assets.decocache.com/vida-veg-b2b/7fc2bea3-2234-48fe-87b9-4ed7588ce5ed/image-(27).png",
+                  "src": "https://decoims.com/vida-veg-b2b/7fc2bea3-2234-48fe-87b9-4ed7588ce5ed/image-(27).png",
                   "alt": "Interior da Fábrica"
                 }
               ],
@@ -67,22 +67,22 @@
               "title": "Nossos selos e certificações",
               "cards": [
                 {
-                  "icon": "https://assets.decocache.com/vida-veg-b2b/6abf3241-5d9f-4327-806e-737eb45b2e01/image-6.png",
+                  "icon": "https://decoims.com/vida-veg-b2b/6abf3241-5d9f-4327-806e-737eb45b2e01/image-6.png",
                   "title": "SELO SVB",
                   "description": "Todos produtos certificados pela SVB sociedade vegetariana Brasileira"
                 },
                 {
-                  "icon": "https://assets.decocache.com/vida-veg-b2b/2dee4b13-229b-4162-9388-e75b11fb79ac/image-7.png",
+                  "icon": "https://decoims.com/vida-veg-b2b/2dee4b13-229b-4162-9388-e75b11fb79ac/image-7.png",
                   "title": "SELO EU RECICLO",
                   "description": "A cada um produto vendido, 1 outra embalagem é reciclada"
                 },
                 {
-                  "icon": "https://assets.decocache.com/vida-veg-b2b/727f3c95-1dd4-4ced-83dd-6a5a947c53ec/image-8-(1).png",
+                  "icon": "https://decoims.com/vida-veg-b2b/727f3c95-1dd4-4ced-83dd-6a5a947c53ec/image-8-(1).png",
                   "title": "SELO KOSHER",
                   "description": "Kosher – Comunidade Judaica"
                 },
                 {
-                  "icon": "https://assets.decocache.com/vida-veg-b2b/f386f6be-c08b-40eb-b072-6c480c2aa4cf/image-9.png",
+                  "icon": "https://decoims.com/vida-veg-b2b/f386f6be-c08b-40eb-b072-6c480c2aa4cf/image-9.png",
                   "title": "SELO KOSHER",
                   "description": "Kosher – Comunidade Judaica"
                 }

--- a/.deco/blocks/pages-Search%2520Page-514254.json
+++ b/.deco/blocks/pages-Search%2520Page-514254.json
@@ -28,31 +28,31 @@
           {
             "productCards": [
               {
-                "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+                "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
                 "label": "Requeijão"
               },
               {
-                "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+                "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
                 "label": "Requeijão"
               },
               {
-                "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+                "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
                 "label": "Requeijão"
               },
               {
-                "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+                "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
                 "label": "Requeijão"
               },
               {
-                "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+                "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
                 "label": "Requeijão"
               },
               {
-                "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+                "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
                 "label": "Requeijão"
               }
             ],
-            "image": "https://assets.decocache.com/vida-veg-b2b/169d5c60-4746-4af6-8352-b99c8672c220/search_bg.png",
+            "image": "https://decoims.com/vida-veg-b2b/169d5c60-4746-4af6-8352-b99c8672c220/search_bg.png",
             "title": "<h1>Nossos <br>Produtos</h1>",
             "description": "<p><span>Se diferencie e destaque o potencial do seu cardápio com </span><strong><span>produtos saudáveis</span></strong><span>. Nosso compromisso é inovação e qualidade para negócios que buscam alimentos </span><strong><span>plant-based</span></strong><span>. Aqui, tudo é desenvolvido para garantir a </span><strong><span>qualidade e a excelência que o seu negócio busca</span></strong><span>.</span></p>",
             "route": "*"

--- a/.deco/blocks/pages-home-c4bcbfb771e9.json
+++ b/.deco/blocks/pages-home-c4bcbfb771e9.json
@@ -11,8 +11,8 @@
       "__resolveType": "site/sections/Images/Carousel.tsx",
       "images": [
         {
-          "desktop": "https://assets.decocache.com/vida-veg-b2b/d704a83f-13b9-4771-b5b5-63366ab3dc0e/Frame-117.png",
-          "mobile": "https://assets.decocache.com/storefront/9c8c0ce3-4ffb-49d6-a8d1-fe17a3db7e86/1742560203848-88b2ad41-be6d-4640-b9fe-c58942362f0f",
+          "desktop": "https://decoims.com/vida-veg-b2b/d704a83f-13b9-4771-b5b5-63366ab3dc0e/Frame-117.png",
+          "mobile": "https://decoims.com/storefront/9c8c0ce3-4ffb-49d6-a8d1-fe17a3db7e86/1742560203848-88b2ad41-be6d-4640-b9fe-c58942362f0f",
           "alt": "Shoes",
           "action": {
             "title": "Skate into Adventure!",
@@ -23,8 +23,8 @@
           "href": "/"
         },
         {
-          "desktop": "https://assets.decocache.com/storefront/98a22637-60b2-41f7-9d49-dbbf99f50472/1742560212519-d26304f4-355b-48d0-b649-e24b9cbf0ded",
-          "mobile": "https://assets.decocache.com/storefront/05748b9f-6c37-4845-aa57-1d2338ece0b8/1742560215958-47a4d85a-1150-4e5d-abc2-5c642445ff12",
+          "desktop": "https://decoims.com/storefront/98a22637-60b2-41f7-9d49-dbbf99f50472/1742560212519-d26304f4-355b-48d0-b649-e24b9cbf0ded",
+          "mobile": "https://decoims.com/storefront/05748b9f-6c37-4845-aa57-1d2338ece0b8/1742560215958-47a4d85a-1150-4e5d-abc2-5c642445ff12",
           "alt": "Men",
           "action": {
             "title": "Discover Fresh Looks",
@@ -35,8 +35,8 @@
           "href": "/"
         },
         {
-          "desktop": "https://assets.decocache.com/storefront/6ee525fa-fcd1-4cbe-be78-eaaa312c0471/1742560219550-1226ef79-c7e0-403c-b716-b6b9af3f2936",
-          "mobile": "https://assets.decocache.com/storefront/9f6167b5-887a-4401-9ac6-1888a9fc32e9/1742560222938-f7ea4cbe-7498-4e64-9205-c741753edfcc",
+          "desktop": "https://decoims.com/storefront/6ee525fa-fcd1-4cbe-be78-eaaa312c0471/1742560219550-1226ef79-c7e0-403c-b716-b6b9af3f2936",
+          "mobile": "https://decoims.com/storefront/9f6167b5-887a-4401-9ac6-1888a9fc32e9/1742560222938-f7ea4cbe-7498-4e64-9205-c741753edfcc",
           "action": {
             "label": "Shop Now!",
             "href": "/women",
@@ -56,22 +56,22 @@
         "deals": [
           {
             "content": "<p><strong><span>15%OFF</span></strong><span> na primeira compra</span></p>",
-            "image": "https://assets.decocache.com/vida-veg-b2b/54173224-13d0-4943-8632-c79f9578f34b/SealPercent.svg",
+            "image": "https://decoims.com/vida-veg-b2b/54173224-13d0-4943-8632-c79f9578f34b/SealPercent.svg",
             "label": "<p><strong><span>15%OFF</span></strong><span> na primeira compra</span></p>"
           },
           {
             "content": "<p><strong><span>15%OFF</span></strong><span> na primeira compra</span></p>",
-            "image": "https://assets.decocache.com/vida-veg-b2b/54173224-13d0-4943-8632-c79f9578f34b/SealPercent.svg",
+            "image": "https://decoims.com/vida-veg-b2b/54173224-13d0-4943-8632-c79f9578f34b/SealPercent.svg",
             "label": "<p><strong><span>15%OFF</span></strong><span> na primeira compra</span></p>"
           },
           {
             "content": "<p><strong><span>15%OFF</span></strong><span> na primeira compra</span></p>",
-            "image": "https://assets.decocache.com/vida-veg-b2b/54173224-13d0-4943-8632-c79f9578f34b/SealPercent.svg",
+            "image": "https://decoims.com/vida-veg-b2b/54173224-13d0-4943-8632-c79f9578f34b/SealPercent.svg",
             "label": "<p><strong><span>15%OFF</span></strong><span> na primeira compra</span></p>"
           },
           {
             "content": "<p><strong><span>15%OFF</span></strong><span> na primeira compra</span></p>",
-            "image": "https://assets.decocache.com/vida-veg-b2b/54173224-13d0-4943-8632-c79f9578f34b/SealPercent.svg",
+            "image": "https://decoims.com/vida-veg-b2b/54173224-13d0-4943-8632-c79f9578f34b/SealPercent.svg",
             "label": "<p><strong><span>15%OFF</span></strong><span> na primeira compra</span></p>"
           }
         ],
@@ -86,27 +86,27 @@
         "subtitle": "<p><span>Temos um portfólio completo com alimentos 100% de base vegetal, gostosos e saudáveis.</span></p>",
         "cards": [
           {
-            "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+            "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
             "label": "Requeijão"
           },
           {
-            "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+            "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
             "label": "Requeijão"
           },
           {
-            "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+            "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
             "label": "Requeijão"
           },
           {
-            "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+            "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
             "label": "Requeijão"
           },
           {
-            "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+            "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
             "label": "Requeijão"
           },
           {
-            "src": "https://assets.decocache.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
+            "src": "https://decoims.com/vida-veg-b2b/51c1826a-0e41-4072-a141-2df4049a94b9/Ellipse-6.png",
             "label": "Requeijão"
           }
         ]

--- a/.deco/blocks/site.json
+++ b/.deco/blocks/site.json
@@ -1,14 +1,14 @@
 {
   "seo": {
     "type": "website",
-    "image": "https://assets.decocache.com/storefront/008e0b89-6d70-4e91-9855-dbbc3d7941f7/1742560188441-74d13a55-4c18-4a5c-8cb4-dcaa27aae923",
+    "image": "https://decoims.com/storefront/008e0b89-6d70-4e91-9855-dbbc3d7941f7/1742560188441-74d13a55-4c18-4a5c-8cb4-dcaa27aae923",
     "title": "Storefront",
     "jsonLDs": [],
     "noIndexing": false,
     "description": "Build profitable websites with deco.cx",
     "titleTemplate": "%s | deco.cx",
     "descriptionTemplate": "%s | deco.cx",
-    "favicon": "https://assets.decocache.com/storefront/3faae4ba-273d-491e-a5a1-0fcd354b7558/1742560192150-e4024f82-e88f-4cc6-94fe-4215fe8faef3"
+    "favicon": "https://decoims.com/storefront/3faae4ba-273d-491e-a5a1-0fcd354b7558/1742560192150-e4024f82-e88f-4cc6-94fe-4215fe8faef3"
   },
   "theme": {
     "__resolveType": "Deco"

--- a/sections/Content/Testimonials.tsx
+++ b/sections/Content/Testimonials.tsx
@@ -29,7 +29,7 @@ export default function Testimonials({
     {
       name: "Monreale",
       avatar:
-        "https://assets.decocache.com/vida-veg-b2b/6a002b7a-0b0d-4724-b2f0-7e5e4a47b301/Group-39217.svg",
+        "https://decoims.com/vida-veg-b2b/6a002b7a-0b0d-4724-b2f0-7e5e4a47b301/Group-39217.svg",
       content:
         "Foi um produto que salvou bastante a gente, porque muita gente que restrição, pessoas que são veganas e os produtos atendem muito bem, em até receitas que vão para o salão.",
       showHeart: true,
@@ -37,7 +37,7 @@ export default function Testimonials({
     {
       name: "Di Blasi",
       avatar:
-        "https://assets.decocache.com/vida-veg-b2b/42f968dd-678d-4fe0-91d4-b6f681009391/Group-(13).svg",
+        "https://decoims.com/vida-veg-b2b/42f968dd-678d-4fe0-91d4-b6f681009391/Group-(13).svg",
       content:
         "Aqui na Di Blasi Pizzas, temos explorado opções mais saudáveis e voltadas ao público vegano e vegetariano. Os produtos Vida Veg tem sido um ótimo complemento, especialmente por serem muito versáteis e de alta qualidade. Eles se integram bem nas preparações sem comprometer o sabor ou a textura, o que é essencial para manter o padrão das nossas pizzas. O feedback dos clientes tem sido positivo, pois muitos apreciam o sabor autêntico e a leveza dos ingredientes.",
       showHeart: true,
@@ -45,7 +45,7 @@ export default function Testimonials({
     {
       name: "Sodexo",
       avatar:
-        "https://assets.decocache.com/vida-veg-b2b/fd04faca-a176-4540-8fbe-fd6472a818b3/Group-39217-(1).svg",
+        "https://decoims.com/vida-veg-b2b/fd04faca-a176-4540-8fbe-fd6472a818b3/Group-39217-(1).svg",
       content:
         "Foi um produto que salvou bastante a gente, porque muita gente que restrição, pessoas que são veganas e os produtos atendem muito bem, em até receitas que vão para o salão.",
       showHeart: true,
@@ -53,7 +53,7 @@ export default function Testimonials({
     {
       name: "Parceiro 4",
       avatar:
-        "https://assets.decocache.com/vida-veg-b2b/695ab70b-3916-4b10-a2ab-01707ffff991/Group-39217-(2).svg",
+        "https://decoims.com/vida-veg-b2b/695ab70b-3916-4b10-a2ab-01707ffff991/Group-39217-(2).svg",
       content:
         "Cuidado com o todo, compromisso e a certeza do propósito fazendo o melhor para uma alimentação saudável, saborosa e nutritiva.",
       showHeart: false,
@@ -61,7 +61,7 @@ export default function Testimonials({
     {
       name: "Monreale",
       avatar:
-        "https://assets.decocache.com/vida-veg-b2b/6a002b7a-0b0d-4724-b2f0-7e5e4a47b301/Group-39217.svg",
+        "https://decoims.com/vida-veg-b2b/6a002b7a-0b0d-4724-b2f0-7e5e4a47b301/Group-39217.svg",
       content:
         "Foi um produto que salvou bastante a gente, porque muita gente que restrição, pessoas que são veganas e os produtos atendem muito bem, em até receitas que vão para o salão.",
       showHeart: true,
@@ -69,7 +69,7 @@ export default function Testimonials({
     {
       name: "Di Blasi",
       avatar:
-        "https://assets.decocache.com/vida-veg-b2b/42f968dd-678d-4fe0-91d4-b6f681009391/Group-(13).svg",
+        "https://decoims.com/vida-veg-b2b/42f968dd-678d-4fe0-91d4-b6f681009391/Group-(13).svg",
       content:
         "Aqui na Di Blasi Pizzas, temos explorado opções mais saudáveis e voltadas ao público vegano e vegetariano. Os produtos Vida Veg tem sido um ótimo complemento, especialmente por serem muito versáteis e de alta qualidade. Eles se integram bem nas preparações sem comprometer o sabor ou a textura, o que é essencial para manter o padrão das nossas pizzas. O feedback dos clientes tem sido positivo, pois muitos apreciam o sabor autêntico e a leveza dos ingredientes.",
       showHeart: true,
@@ -77,7 +77,7 @@ export default function Testimonials({
     {
       name: "Sodexo",
       avatar:
-        "https://assets.decocache.com/vida-veg-b2b/fd04faca-a176-4540-8fbe-fd6472a818b3/Group-39217-(1).svg",
+        "https://decoims.com/vida-veg-b2b/fd04faca-a176-4540-8fbe-fd6472a818b3/Group-39217-(1).svg",
       content:
         "Foi um produto que salvou bastante a gente, porque muita gente que restrição, pessoas que são veganas e os produtos atendem muito bem, em até receitas que vão para o salão.",
       showHeart: true,
@@ -85,7 +85,7 @@ export default function Testimonials({
     {
       name: "Parceiro 4",
       avatar:
-        "https://assets.decocache.com/vida-veg-b2b/695ab70b-3916-4b10-a2ab-01707ffff991/Group-39217-(2).svg",
+        "https://decoims.com/vida-veg-b2b/695ab70b-3916-4b10-a2ab-01707ffff991/Group-39217-(2).svg",
       content:
         "Cuidado com o todo, compromisso e a certeza do propósito fazendo o melhor para uma alimentação saudável, saborosa e nutritiva.",
       showHeart: false,

--- a/sections/Footer/Footer.tsx
+++ b/sections/Footer/Footer.tsx
@@ -307,7 +307,7 @@ function Footer({
                 <img
                   width={97}
                   height={17}
-                  src="https://assets.decocache.com/vida-veg-b2b/d3d67d8a-7381-4383-9aea-bfc2feaf0e07/Group-697.svg"
+                  src="https://decoims.com/vida-veg-b2b/d3d67d8a-7381-4383-9aea-bfc2feaf0e07/Group-697.svg"
                 />
               </a>
             </div>


### PR DESCRIPTION
## Migração de assets legados

Substitui todas as referências de:
- `assets.decocache.com` → `decoims.com`
- `data.decoassets.com` → `decoims.com`

**11 arquivo(s) alterado(s):**
- `sections/Footer/Footer.tsx`
- `sections/Content/Testimonials.tsx`
- `.deco/blocks/pages-Quem%2520Somos-262067.json`
- `.deco/blocks/site.json`
- `.deco/blocks/Header.json`
- `.deco/blocks/pages-home-c4bcbfb771e9.json`
- `.deco/blocks/Footer.json`
- `.deco/blocks/Shoppable%20Banner%20-%2001.json`
- `.deco/blocks/pages-Search%2520Page-514254.json`
- `.deco/blocks/Category%20Banner%20-%2001.json`
- `.deco/blocks/LinkTree%20-%2001.json`